### PR TITLE
Ekala/feat/add-support-for-permissions-to-hub-applications

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,6 @@ repos:
     repo: https://github.com/aws-ia/pre-commit-configs
     # To update run:
     # pre-commit autoupdate --freeze
-    rev: 82b2dd4f3c3c8b064ce15c7cc518e14c43f6a068  # frozen: v1.4.1
+    rev: b3e647e360f04623c6c582c12245fc92e20cc2e8  # frozen: v1.6.3
     hooks:
       - id: aws-ia-meta-hook

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,7 +3,7 @@
 
 plugin "aws" {
   enabled = true
-  version = "0.14.0"
+  version = "0.24.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,12 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_components"></a> [app\_components](#input\_app\_components) | The application's app-components, including its resources | <pre>list(object({<br>    app_component_name = string<br>    app_component_type = string<br>    resources = list(object({<br>      resource_name            = string<br>      resource_type            = string<br>      resource_identifier      = string<br>      resource_identifier_type = string<br>      resource_region          = string<br>    }))<br>  }))</pre> | n/a | yes |
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | The Application's name | `string` | n/a | yes |
+| <a name="input_permission_type"></a> [permission\_type](#input\_permission\_type) | How AWS Resilience Hub should scan the resources. Either `LegacyIAMUser` or `RoleBased` | `string` | n/a | yes |
 | <a name="input_rpo"></a> [rpo](#input\_rpo) | RPO across all failure metrics | `number` | n/a | yes |
 | <a name="input_rto"></a> [rto](#input\_rto) | RTO across all failure metrics | `number` | n/a | yes |
 | <a name="input_s3_state_file_url"></a> [s3\_state\_file\_url](#input\_s3\_state\_file\_url) | An URL to s3-backend Terraform state-file | `string` | n/a | yes |
+| <a name="input_cross_account_role_arns"></a> [cross\_account\_role\_arns](#input\_cross\_account\_role\_arns) | The list of IAM Role ARNs to be used for querying purposes in other AWS accounts while importing resources and assessing your appliaction | `list(string)` | `[]` | no |
+| <a name="input_invoker_role_name"></a> [invoker\_role\_name](#input\_invoker\_role\_name) | The IAM role name that will be used by AWS Resilience Hub for read-only access to the application resources while running an assessment | `string` | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 AWS Resilience Hub lets you define your RTO and RPO objectives for each of your applications. Then it assesses your application’s configuration to ensure it meets your requirements. It provides actionable recommendations and a resilience score to help you track your application’s resiliency progress over time.
 This Terraform module contains AWS Resilience Hub resources.
 
-The module will be s3 state-file backed, as it is currently mandatory by Resilience Hub to onboard new terraform-Application using s3 only.\
-As a result, we must provide the module with `s3_state_file_url` where the actual resources are deployed.
+The resources that make up the application tracked by [AWS Resilience Hub](https://aws.amazon.com/blogs/aws/monitor-and-improve-your-application-resiliency-with-resilience-hub) must be managed in a tfstate file that [exists in S3](https://www.terraform.io/language/settings/backends/s3). This is a requirement of the service. As such, the argument `s3_state_file_url` is required and must point to the tfstate file where the resources are managed.
+If possible, our recommendation is to maintain your application deployment in the same [root module](https://www.terraform.io/docs/glossary#root-module) as the Resilience Hub app definition deployment. See our [basic example](https://github.com/aws-ia/terraform-aws-resiliencehub-app/tree/main/examples).
 
 The `app-components` variable is an object list composed of the following schema:
 ```
@@ -44,14 +44,14 @@ A single resources is composed of:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72.0 |
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.21.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_awscc"></a> [awscc](#provider\_awscc) | >= 0.21.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,11 @@ resource "awscc_resiliencehub_app" "app" {
   })
   resource_mappings     = local.resource_mappings
   resiliency_policy_arn = awscc_resiliencehub_resiliency_policy.policy.policy_arn
+  permission_model = {
+    type                    = var.permission_type
+    cross_account_role_arns = var.cross_account_role_arns
+    invoker_role_name       = var.invoker_role_name
+  }
 }
 
 resource "awscc_resiliencehub_resiliency_policy" "policy" {

--- a/providers.tf
+++ b/providers.tf
@@ -11,7 +11,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0.0"
+      version = "~> 3.5.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,19 @@ variable "rpo" {
   type        = number
   description = "RPO across all failure metrics"
 }
+
+variable "permission_type" {
+  description = "How AWS Resilience Hub should scan the resources. Either `LegacyIAMUser` or `RoleBased`"
+  type        = string
+}
+
+variable "invoker_role_name" {
+  description = "The IAM role name that will be used by AWS Resilience Hub for read-only access to the application resources while running an assessment"
+  type        = string
+  default     = null
+}
+variable "cross_account_role_arns" {
+  description = "The list of IAM Role ARNs to be used for querying purposes in other AWS accounts while importing resources and assessing your appliaction"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
This is so that users have the ability to configure the roles and credentials to be used for for creating the application, importing its resources and running an assessment. Otherwise, the user will have to manually specify these via the AWS console